### PR TITLE
use avr-libc TWI symbols

### DIFF
--- a/TWI_Slave/common_define.h
+++ b/TWI_Slave/common_define.h
@@ -27,15 +27,6 @@
 
 #define FLASH_SIZE 8192
 
-// 8KB of flash divided by pages of size 64 bytes
-#define TOTAL_NO_OF_PAGES  (FLASH_SIZE / PAGE_SIZE)
-
-// The number of pages being used for bootloader code
-#define BOOTLOADER_PAGES          	(TOTAL_NO_OF_PAGES - BOOT_PAGE_ADDRESS/PAGE_SIZE)
-
-// For bounds check during page write/erase operation to protect the bootloader code from being corrupted
-#define LAST_PAGE_NO_TO_BE_ERASED 	(TOTAL_NO_OF_PAGES - BOOTLOADER_PAGES)
-
 
 /*****************************************************************************/
 /*****************************************************************************/
@@ -44,22 +35,6 @@
 
 
 uint8_t pageBuffer[PAGE_SIZE];
-/*****************************************************************************/
-/*****************************************************************************/
-
-
-
-/*****************************************************************************/
-/*****************************************************************************/
-
-#define STATUSMASK_SPMBUSY 		0x01	// The mask bit for SPM busy status code
-#define STATUSMASK_BLSCERR              0x02    // The mask bit for attempt to override bootloader section
-#define STATUSMASK_TWIABORT             0x04    // The mask bit for indicating TWI abort fn called
-#define STATUSMASK_SLTR_BUSY            0x08    // The mask bit for slave transmit
-#define STATUSMASK_SLRBAA_BUSY          0x10    // The mask bit for slave receive and ack
-#define STATUSMASK_SLRBAN_BUSY          0x20    // The mask bit for slave receive and Nack
-#define STATUSMASK_EEPROM_BUSY          0x40    // The mask bit for EEPROM busy
-#define STATUSMASK_BOOTLOADER           0x80    // The mask bit for bootloader operations
 /*****************************************************************************/
 /*****************************************************************************/
 

--- a/TWI_Slave/common_define.h
+++ b/TWI_Slave/common_define.h
@@ -1,5 +1,3 @@
-#include <avr/boot.h>
-
 /*****************************************************************************/
 #define TWI_CMD_PAGEUPDATE_ADDR         0x01	// TWI Command to program a flash page address to write
 #define TWI_CMD_PAGEUPDATE_FRAME        0x02	// TWI Command to program the next frame of the page of flash

--- a/TWI_Slave/twi_slave.c
+++ b/TWI_Slave/twi_slave.c
@@ -319,7 +319,7 @@ void process_slave_receive() {
 
     case TWI_CMD_EXECUTEAPP:
         wdt_enable(WDTO_15MS);  // Set WDT min for cleanup using reset
-        asm volatile ("HERE:rjmp HERE");//Yes it's an infinite loop
+        asm volatile ("1: rjmp 1b"); // Loop until WDT reset kicks in
         __builtin_unreachable();
     // fall through
     case TWI_CMD_ERASEFLASH:

--- a/TWI_Slave/twi_slave.c
+++ b/TWI_Slave/twi_slave.c
@@ -12,11 +12,6 @@
 // AD01: lower two bits of device address
 #define AD01 (PINB & (_BV(0) | _BV(1)))
 
-//configuring LAST_INTVECT_ADDRESS as per device selected
-/*****************************************************************************/
-#define LAST_INTVECT_ADDRESS 		TWI_vect // The start of the application code
-
-
 /*****************************************************************************/
 #define ACK TW_SR_DATA_ACK
 #define NAK TW_SR_DATA_NACK


### PR DESCRIPTION
Use the TWI hardware module status symbols from `<util/twi.h>` from avr-libc instead of defining our own. Also clean up various unused things, and tidy up includes.

Confirmed to compile to identical machine code.
